### PR TITLE
Add CRC validation and slow default clock to 1 kHz

### DIFF
--- a/src/com-prot.h
+++ b/src/com-prot.h
@@ -8,7 +8,7 @@
   - DATA open-drain: 1=release (INPUT / open-drain HIGH), 0=drive low (OUTPUT LOW)
   - Bit symbol (payload): logical 0 -> "00", logical 1 -> "11" (cells)
   - SYNC (cells): "000111000111000" (15 cells, odd-length runs; cannot occur in data)
-  - Frame: MTYPE(2) + A(6) + CMD(4)  => 12 logical bits => 24 cells
+  - Frame: MTYPE(2) + A(6) + CMD(4) + CRC(4)  => 16 logical bits => 32 cells
   - Reply windows:
       PRESENCE2 (after POLL_ID): 2 cells; YES="00", NO="11"
       TYPE12    (after CMD_TO_ID with CMD=0): 12 cells; TYPE(6) encoded as dibits
@@ -22,7 +22,7 @@ struct Pins {
   uint8_t data;  // open-drain
 };
 
-static const uint16_t CELL_US_DEFAULT = 40;    // 25 kHz cell clock
+static const uint16_t CELL_US_DEFAULT = 1000;  // 1 kHz cell clock
 static const uint8_t  MAX_SLAVES_HINT = 20;
 
 // ---------- Encoding helpers ----------
@@ -30,6 +30,13 @@ inline void encode12_to_24cells(uint16_t bits12, uint8_t *cells24) {
   for (int i=11, w=0; i>=0; --i) {
     uint8_t b = (bits12 >> i) & 1;
     cells24[w++] = b; cells24[w++] = b;
+  }
+}
+
+inline void encode16_to_32cells(uint16_t bits16, uint8_t *cells32) {
+  for (int i=15, w=0; i>=0; --i) {
+    uint8_t b = (bits16 >> i) & 1;
+    cells32[w++] = b; cells32[w++] = b;
   }
 }
 
@@ -51,6 +58,22 @@ inline uint16_t pack12(uint8_t mtype2, uint8_t A6, uint8_t cmd4) {
   return ((uint16_t)(mtype2 & 0x3) << 10) |
          ((uint16_t)(A6 & 0x3F)  << 4)  |
          ((uint16_t)(cmd4 & 0x0F));
+}
+
+inline uint8_t crc4(uint16_t bits12) {
+  uint8_t crc = 0;
+  for (int i = 11; i >= 0; --i) {
+    uint8_t bit = (bits12 >> i) & 1;
+    crc = ((crc << 1) | bit) & 0x1F; // shift in bit
+    if (crc & 0x10) crc ^= 0x3;      // polynomial x^4 + x + 1 (0b10011)
+  }
+  return crc & 0x0F;
+}
+
+inline uint16_t pack16_with_crc(uint8_t mtype2, uint8_t A6, uint8_t cmd4) {
+  uint16_t bits12 = pack12(mtype2, A6, cmd4);
+  uint8_t c = crc4(bits12);
+  return (uint16_t)((bits12 << 4) | c);
 }
 
 // ---------- Open-drain helpers (non-ISR use OK) ----------
@@ -136,7 +159,7 @@ private:
   enum RespMode : uint8_t { RESP_NONE=0, RESP_PRESENCE2=1, RESP_TYPE12=2 };
   volatile RespMode respMode = RESP_NONE;
 
-  static const uint16_t MAX_CELLS = 15 + 24 + 2; // SYNC + payload + GUARD
+  static const uint16_t MAX_CELLS = 15 + 32 + 2; // SYNC + payload(+CRC) + GUARD
   volatile uint8_t  txCells[MAX_CELLS];
   volatile uint16_t txLen = 0;
   volatile uint16_t cellIdx = 0;
@@ -210,7 +233,7 @@ private:
   volatile uint16_t syncWindow = 0;
 
   // payload
-  volatile uint8_t  recvCells[24];
+  volatile uint8_t  recvCells[32];
   volatile uint8_t  recvIdx = 0;
 
   // counters
@@ -243,7 +266,7 @@ private:
 
   // helpers
   void handleDecoded(uint8_t mtype, uint8_t A6, uint8_t cmd4);
-  static uint8_t IRAM_ATTR decode12_from_24cells(const volatile uint8_t *cells24, uint16_t &bits12_out);
+  static uint8_t IRAM_ATTR decode16_from_32cells(const volatile uint8_t *cells32, uint16_t &bits16_out);
 };
 
 } // namespace StarWire


### PR DESCRIPTION
## Summary
- Append a 4-bit CRC to command frames and verify it on slaves, expanding payload to 32 cells
- Guard against idle-bus TYPE replies that never pull data low
- Default cell period set to 1 ms and document ~320 bit/s throughput

## Testing
- `pip install platformio`
- `pio run` *(fails: Not a PlatformIO project; `platformio.ini` is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a8407463bc832db9551703e5088c9a